### PR TITLE
Use a bitfield sequence to configure LED behaviour for gamepad status.

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
   "port": 80,
   "useGamepadByDefault": false,
   "analog": true,
-  "logLevel": "info"
+  "logLevel": "info",
+  "ledBitFieldSequence": [1,2,4,8,9,10,12,13,14,15]
 }


### PR DESCRIPTION
Integrating changes from here to allow for more than four virtual controllers:

https://github.com/jehervy/node-virtual-gamepads/commit/619a0b0d80230b4200c6fc162d6c3292670b1fbb#
