### PR TITLE
Use a bitfield sequence to configure LED behaviour for gamepad status.

### DIFF
--- a/server.js
+++ b/server.js
@@ -71,11 +71,14 @@ Virtual gamepad application
     });
     socket.on('connectGamepad', function() {
       return gp_hub.connectGamepad(function(gamePadId) {
+        var ledBitField;
+        ledBitField = config.ledBitFieldSequence[gamePadId];
         if (gamePadId !== -1) {
           log('info', 'connectGamepad: success');
           socket.gamePadId = gamePadId;
           return socket.emit('gamepadConnected', {
-            padId: gamePadId
+            padId: gamePadId,
+            ledBitField: ledBitField
           });
         } else {
           return log('warning', 'connectGamepad: failed');


### PR DESCRIPTION
Integrating changes from here to allow for more than four virtual controllers:

https://github.com/jehervy/node-virtual-gamepads/commit/619a0b0d80230b4200c6fc162d6c3292670b1fbb#
